### PR TITLE
Fix campaign metrics persistence

### DIFF
--- a/pages/campaign-edit.html
+++ b/pages/campaign-edit.html
@@ -1645,7 +1645,7 @@ Thanks for considering,
         bindEvents() {
             // Edit mode buttons
             $('#edit-campaign-btn').addEventListener('click', () => this.toggleEditMode(true));
-            $('#save-campaign-btn').addEventListener('click', () => this.saveCampaign());
+            $('#save-campaign-btn').addEventListener('click', () => this.saveCampaign(true));
             $('#cancel-edit-btn').addEventListener('click', () => this.toggleEditMode(false));
 
             // Add item buttons
@@ -2248,8 +2248,10 @@ Thanks for considering,
             this.renderImpactMetrics();
             this.closeModal('metric-modal');
             this.utils.showNotification('Metric saved successfully');
+            // Persist changes to the server without leaving the page
+            this.saveCampaign(false);
         },
-        
+
         saveMilestone() {
             const id = $('#milestone-id').value;
             const newMilestone = {
@@ -2277,6 +2279,8 @@ Thanks for considering,
             this.renderMilestones();
             this.closeModal('milestone-modal');
             this.utils.showNotification('Milestone saved successfully');
+            // Persist changes to the server without leaving the page
+            this.saveCampaign(false);
         },
         
         saveMedia() {
@@ -2329,7 +2333,7 @@ Thanks for considering,
             this.utils.showNotification(`${type.charAt(0).toUpperCase() + type.slice(1)} deleted successfully`);
         },
         
-        async saveCampaign() {
+        async saveCampaign(redirect = true) {
             // Collect form data
             console.log(this.data);
             const updatedCampaign = {
@@ -2376,11 +2380,11 @@ Thanks for considering,
             .then(data => {
                 console.log(data);
                 this.data = data;
-                this.toggleEditMode(false);
+                if (redirect) this.toggleEditMode(false);
                 this.utils.showNotification('Campaign updated successfully');
-                
+
                 // Update SEO data after campaign update
-                this.initSeoFromCampaign();
+                if (redirect) this.initSeoFromCampaign();
             })
             .catch(error => {
                 console.error('Error updating campaign:', error);
@@ -2389,7 +2393,9 @@ Thanks for considering,
                 console.log('Campaign updated');
                 console.log(passData);
                 this.state.loaded = true;
-                location.href='/pages/campaign-detail.html?id=' + passData._id;
+                if (redirect) {
+                    location.href='/pages/campaign-detail.html?id=' + passData._id;
+                }
             });
         },
         


### PR DESCRIPTION
## Summary
- persist metrics and milestones when editing campaigns
- support non-redirect campaign saves when called from metrics/milestone forms
- invoke campaign save from metric and milestone modals

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Class "MongoDB\Driver\Manager" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876994bb05c83239caaca63fbb50d1d