### PR TITLE
Add task notes update script

### DIFF
--- a/api.php
+++ b/api.php
@@ -264,6 +264,13 @@ if ($endpoint === 'kyc' || (isset($pathParts) && $pathParts[0] === 'kyc')) {
                 exit;
             }
             break;
+
+        case 'risk-score':
+            if ($method === 'POST') {
+                $kycController->updateRiskScore();
+                exit;
+            }
+            break;
             
         default:
             http_response_code(404);

--- a/lib/JumioService.php
+++ b/lib/JumioService.php
@@ -207,6 +207,11 @@ class JumioService {
             
             // Send notification to user about verification result
             $this->notifyUser($userId, $verificationResult, $payload);
+
+            // Recalculate user's risk score after verification update
+            require_once __DIR__ . '/RiskScoringService.php';
+            $riskService = new RiskScoringService();
+            $riskService->calculateRiskScore((string)$userId);
             
             return [
                 'success' => true,

--- a/lib/KycController.php
+++ b/lib/KycController.php
@@ -166,6 +166,32 @@ class KycController {
     }
 
     /**
+     * Calculate and update the authenticated user's risk score
+     *
+     * @return array Result with score and level
+     */
+    public function updateRiskScore() {
+        try {
+            $userId = $this->getUserId();
+            if (!$userId) {
+                return $this->sendErrorResponse('Authentication required', 401);
+            }
+
+            require_once __DIR__ . '/RiskScoringService.php';
+            $service = new RiskScoringService();
+            $result = $service->calculateRiskScore($userId);
+
+            if ($result['success']) {
+                return $this->sendJsonResponse($result);
+            }
+
+            return $this->sendErrorResponse($result['error'] ?? 'Unable to calculate risk score');
+        } catch (Exception $e) {
+            return $this->sendErrorResponse($e->getMessage(), 500);
+        }
+    }
+
+    /**
      * Check if a user is verified (internal API)
      * 
      * @param string $userId User ID to check

--- a/lib/RiskScoringService.php
+++ b/lib/RiskScoringService.php
@@ -1,0 +1,83 @@
+<?php
+// lib/RiskScoringService.php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/JumioService.php';
+
+class RiskScoringService {
+    private $db;
+    private $usersCollection;
+    private $transactionsCollection;
+
+    private $highRiskCountries = [
+        'IR', 'KP', 'SY', 'CU', 'SD', 'RU'
+    ];
+
+    public function __construct() {
+        $this->db = Database::getInstance();
+        $this->usersCollection = $this->db->getCollection('users');
+        $this->transactionsCollection = $this->db->getCollection('blockchain_transactions');
+    }
+
+    /**
+     * Calculate and update a user's risk score.
+     *
+     * @param string $userId MongoDB ID string
+     * @return array{success:bool, score?:int, level?:string, error?:string}
+     */
+    public function calculateRiskScore($userId) {
+        try {
+            $user = $this->usersCollection->findOne(['_id' => new MongoDB\BSON\ObjectId($userId)]);
+            if (!$user) {
+                return ['success' => false, 'error' => 'User not found'];
+            }
+
+            $score = 0;
+
+            // Factor: high risk country
+            $country = $user['personalInfo']['country'] ?? '';
+            if ($country && in_array(strtoupper($country), $this->highRiskCountries)) {
+                $score += 40;
+            }
+
+            // Factor: transaction activity in last 24h
+            $since = new MongoDB\BSON\UTCDateTime((time() - 86400) * 1000);
+            $txCount = $this->transactionsCollection->count([
+                'userId' => $userId,
+                'createdAt' => ['$gte' => $since]
+            ]);
+            if ($txCount > 10) {
+                $score += 20;
+            }
+
+            // Factor: verification status
+            $jumio = new JumioService();
+            $verification = $jumio->getVerificationStatus($userId);
+            if (!($verification['success'] && $verification['verified'])) {
+                $score += 30;
+            }
+
+            $score = min(100, $score);
+            if ($score >= 70) {
+                $level = 'high';
+            } elseif ($score >= 40) {
+                $level = 'medium';
+            } else {
+                $level = 'low';
+            }
+
+            $this->usersCollection->updateOne(
+                ['_id' => new MongoDB\BSON\ObjectId($userId)],
+                ['$set' => [
+                    'riskScore' => $score,
+                    'riskLevel' => $level,
+                    'updatedAt' => new MongoDB\BSON\UTCDateTime()
+                ]]
+            );
+
+            return ['success' => true, 'score' => $score, 'level' => $level];
+        } catch (Exception $e) {
+            error_log('Risk scoring error: ' . $e->getMessage());
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+}

--- a/scripts/update_task_notes.sh
+++ b/scripts/update_task_notes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+TASKS_JSON=$1
+API_URL="https://project.thegivehub.com/handle_tasks.php"
+
+jq -c '.[] | select(.tranche == "2" and .completed=="1") | {id, task_name}' "$TASKS_JSON" | while read -r row; do
+  id=$(echo "$row" | jq -r '.id')
+  name=$(echo "$row" | jq -r '.task_name')
+  # escape special characters for grep
+  search=$(echo "$name" | sed 's/[].*^$\\/]/\\&/g')
+  commit=$(git log --grep="$search" -n 1 --pretty=format:%h || true)
+  if [ -n "$commit" ]; then
+    note="Completed in commit $commit"
+  else
+    note="Completed"
+  fi
+  curl -s -X POST "$API_URL" -d "action=update_notes&task_id=$id&notes=$(echo $note | sed 's/ /%20/g')" >/dev/null
+  echo "Updated task $id with note: $note"
+done
+


### PR DESCRIPTION
## Summary
- add `update_task_notes.sh` to automate posting notes
- implement new risk scoring service for KYC
- trigger risk score update after Jumio webhook
- expose `/kyc/risk-score` endpoint to recompute score

## Testing
- `php run-tests.php` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_686d2a5c993c8323852357a83ba4c57b