### PR TITLE
Add task notes update script

### DIFF
--- a/api.php
+++ b/api.php
@@ -264,6 +264,20 @@ if ($endpoint === 'kyc' || (isset($pathParts) && $pathParts[0] === 'kyc')) {
                 exit;
             }
             break;
+
+        case 'compliance':
+            if ($method === 'GET') {
+                $kycController->generateComplianceReport();
+                exit;
+            }
+            break;
+
+        case 'risk-score':
+            if ($method === 'POST') {
+                $kycController->updateRiskScore();
+                exit;
+            }
+            break;
             
         default:
             http_response_code(404);

--- a/docs/kyc/kyc-implementation-guide.md
+++ b/docs/kyc/kyc-implementation-guide.md
@@ -72,6 +72,7 @@ Create a new collection in MongoDB called `kyc_verifications` to store verificat
 - **GET /api/kyc/status**: Get verification status for current user
 - **POST /api/kyc/admin-override**: Admin override for verification status
 - **GET /api/kyc/report**: Generate report of verification data
+- **GET /api/kyc/compliance**: Generate compliance report with risk statistics
 
 ## 6. Testing the Integration
 
@@ -159,7 +160,7 @@ Before going to production:
 
 - Connect verification status with user privileges in your app
 - Integrate with fraud detection systems
-- Add compliance reporting features
+- Add compliance reporting features via `/api/kyc/compliance`
 - Link with account approval workflows
 
 ## 11. Maintenance

--- a/kyc-api.php
+++ b/kyc-api.php
@@ -74,6 +74,16 @@ try {
             }
             $kycController->generateReport();
             break;
+
+        case 'compliance':
+            // GET /api/kyc/compliance - Generate compliance report
+            if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+                http_response_code(405);
+                echo json_encode(['error' => 'Method not allowed']);
+                exit;
+            }
+            $kycController->generateComplianceReport();
+            break;
             
         default:
             // Route not found

--- a/lib/APIConfig.js
+++ b/lib/APIConfig.js
@@ -23,7 +23,8 @@ class APIConfig {
                 INITIATE: '/kyc/initiate',
                 STATUS: '/kyc/status',
                 ADMIN_OVERRIDE: '/kyc/admin-override',
-                REPORT: '/kyc/report'
+                REPORT: '/kyc/report',
+                COMPLIANCE: '/kyc/compliance'
             }
         };
     }

--- a/lib/JumioService.php
+++ b/lib/JumioService.php
@@ -207,6 +207,11 @@ class JumioService {
             
             // Send notification to user about verification result
             $this->notifyUser($userId, $verificationResult, $payload);
+
+            // Recalculate user's risk score after verification update
+            require_once __DIR__ . '/RiskScoringService.php';
+            $riskService = new RiskScoringService();
+            $riskService->calculateRiskScore((string)$userId);
             
             return [
                 'success' => true,
@@ -448,6 +453,73 @@ class JumioService {
             ];
         } catch (Exception $e) {
             error_log('KYC report generation error: ' . $e->getMessage());
+            return [
+                'success' => false,
+                'error' => $e->getMessage()
+            ];
+        }
+    }
+
+    /**
+     * Generate compliance report aggregating KYC and risk data
+     *
+     * @param array $filters Optional date range filters
+     * @return array Report data
+     */
+    public function generateComplianceReport($filters = []) {
+        try {
+            $query = [];
+
+            if (isset($filters['startDate'])) {
+                $start = new DateTime($filters['startDate']);
+                $query['createdAt']['$gte'] = new MongoDB\BSON\UTCDateTime($start->getTimestamp() * 1000);
+            }
+
+            if (isset($filters['endDate'])) {
+                $end = new DateTime($filters['endDate']);
+                $end->setTime(23, 59, 59);
+                $query['createdAt']['$lte'] = new MongoDB\BSON\UTCDateTime($end->getTimestamp() * 1000);
+            }
+
+            // Fetch verification records within the window
+            $verifications = $this->kycCollection->find($query);
+
+            $statusCounts = [
+                'APPROVED' => 0,
+                'REJECTED' => 0,
+                'PENDING' => 0,
+                'ERROR' => 0,
+                'EXPIRED' => 0
+            ];
+
+            foreach ($verifications as $verification) {
+                $result = $verification['verificationResult'] ?? 'PENDING';
+                if (isset($statusCounts[$result])) {
+                    $statusCounts[$result]++;
+                }
+            }
+
+            // Aggregate risk levels
+            $users = $this->db->getCollection('users');
+            $riskCounts = [
+                'high' => $users->count(['riskLevel' => 'high']),
+                'medium' => $users->count(['riskLevel' => 'medium']),
+                'low' => $users->count(['riskLevel' => 'low'])
+            ];
+
+            $highRiskUsers = $users->find(
+                ['riskLevel' => 'high'],
+                ['projection' => ['email' => 1, 'displayName' => 1, 'riskScore' => 1]]
+            );
+
+            return [
+                'success' => true,
+                'statusCounts' => $statusCounts,
+                'riskCounts' => $riskCounts,
+                'highRiskUsers' => $highRiskUsers
+            ];
+        } catch (Exception $e) {
+            error_log('Compliance report generation error: ' . $e->getMessage());
             return [
                 'success' => false,
                 'error' => $e->getMessage()

--- a/lib/RiskScoringService.php
+++ b/lib/RiskScoringService.php
@@ -1,0 +1,83 @@
+<?php
+// lib/RiskScoringService.php
+require_once __DIR__ . '/db.php';
+require_once __DIR__ . '/JumioService.php';
+
+class RiskScoringService {
+    private $db;
+    private $usersCollection;
+    private $transactionsCollection;
+
+    private $highRiskCountries = [
+        'IR', 'KP', 'SY', 'CU', 'SD', 'RU'
+    ];
+
+    public function __construct() {
+        $this->db = Database::getInstance();
+        $this->usersCollection = $this->db->getCollection('users');
+        $this->transactionsCollection = $this->db->getCollection('blockchain_transactions');
+    }
+
+    /**
+     * Calculate and update a user's risk score.
+     *
+     * @param string $userId MongoDB ID string
+     * @return array{success:bool, score?:int, level?:string, error?:string}
+     */
+    public function calculateRiskScore($userId) {
+        try {
+            $user = $this->usersCollection->findOne(['_id' => new MongoDB\BSON\ObjectId($userId)]);
+            if (!$user) {
+                return ['success' => false, 'error' => 'User not found'];
+            }
+
+            $score = 0;
+
+            // Factor: high risk country
+            $country = $user['personalInfo']['country'] ?? '';
+            if ($country && in_array(strtoupper($country), $this->highRiskCountries)) {
+                $score += 40;
+            }
+
+            // Factor: transaction activity in last 24h
+            $since = new MongoDB\BSON\UTCDateTime((time() - 86400) * 1000);
+            $txCount = $this->transactionsCollection->count([
+                'userId' => $userId,
+                'createdAt' => ['$gte' => $since]
+            ]);
+            if ($txCount > 10) {
+                $score += 20;
+            }
+
+            // Factor: verification status
+            $jumio = new JumioService();
+            $verification = $jumio->getVerificationStatus($userId);
+            if (!($verification['success'] && $verification['verified'])) {
+                $score += 30;
+            }
+
+            $score = min(100, $score);
+            if ($score >= 70) {
+                $level = 'high';
+            } elseif ($score >= 40) {
+                $level = 'medium';
+            } else {
+                $level = 'low';
+            }
+
+            $this->usersCollection->updateOne(
+                ['_id' => new MongoDB\BSON\ObjectId($userId)],
+                ['$set' => [
+                    'riskScore' => $score,
+                    'riskLevel' => $level,
+                    'updatedAt' => new MongoDB\BSON\UTCDateTime()
+                ]]
+            );
+
+            return ['success' => true, 'score' => $score, 'level' => $level];
+        } catch (Exception $e) {
+            error_log('Risk scoring error: ' . $e->getMessage());
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+}

--- a/scripts/update_task_notes.sh
+++ b/scripts/update_task_notes.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+TASKS_JSON=$1
+API_URL="https://project.thegivehub.com/handle_tasks.php"
+
+jq -c '.[] | select(.tranche == "2" and .completed=="1") | {id, task_name}' "$TASKS_JSON" | while read -r row; do
+  id=$(echo "$row" | jq -r '.id')
+  name=$(echo "$row" | jq -r '.task_name')
+  # escape special characters for grep
+  search=$(echo "$name" | sed 's/[].*^$\\/]/\\&/g')
+  commit=$(git log --grep="$search" -n 1 --pretty=format:%h || true)
+  if [ -n "$commit" ]; then
+    note="Completed in commit $commit"
+  else
+    note="Completed"
+  fi
+  curl -s -X POST "$API_URL" -d "action=update_notes&task_id=$id&notes=$(echo $note | sed 's/ /%20/g')" >/dev/null
+  echo "Updated task $id with note: $note"
+done
+


### PR DESCRIPTION
## Summary
- add `update_task_notes.sh` to automate posting notes
- implement new risk scoring service for KYC
- trigger risk score update after Jumio webhook
- expose `/kyc/risk-score` endpoint to recompute score
- add compliance reporting queries and endpoint

## Testing
- `php run-tests.php` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_686d2a5c993c8323852357a83ba4c57b