### PR TITLE
Add admin review states and endpoints

### DIFF
--- a/admin/kyc-admin.html
+++ b/admin/kyc-admin.html
@@ -699,17 +699,7 @@
             async function loadVerificationData() {
                 try {
                     const filters = getFilters();
-                    let url = '/api.php/admin/kyc/report';
-                    
-                    // Add filters to URL if present
-                    const params = [];
-                    if (filters.status) params.push(`status=${filters.status}`);
-                    if (filters.startDate) params.push(`startDate=${filters.startDate}`);
-                    if (filters.endDate) params.push(`endDate=${filters.endDate}`);
-                    
-                    if (params.length > 0) {
-                        url += '?' + params.join('&');
-                    }
+                    let url = '/api/kyc/pending';
                     
                     // Start loading indicator
                     verificationList.innerHTML = `<tr><td colspan="6" class="text-center">Loading verification data...</td></tr>`;
@@ -735,11 +725,9 @@
                     }
                     
                     const data = await response.json();
-                    
-                    // Update statistics
-                    updateStats(data.stats);
-                    
-                    // Display verifications
+
+                    updateStats({ pending_review: data.verifications.length });
+
                     displayVerifications(data.verifications);
                 } catch (error) {
                     console.error('Error loading verification data:', error);
@@ -758,7 +746,7 @@
                 statTotal.textContent = stats.total || 0;
                 statApproved.textContent = stats.approved || 0;
                 statRejected.textContent = stats.rejected || 0;
-                statPending.textContent = stats.pending || 0;
+                statPending.textContent = stats.pending_review || 0;
             }
 
             // Display verifications in the table
@@ -786,12 +774,13 @@
                             <td>${formatDate(v.updated)}</td>
                             <td>
                                 <div class="action-buttons">
-                                    <button class="btn btn-sm btn-outline view-details" data-id="${v.id}">
+                                    <button class="btn btn-sm btn-outline view-details" data-id="${v._id}">
                                         <i class="fas fa-eye"></i>
                                     </button>
-                                    <button class="btn btn-sm btn-primary override-btn" data-id="${v.id}" data-user="${v.userId}" data-username="${v.userName}" data-email="${v.email}">
-                                        <i class="fas fa-edit"></i>
-                                    </button>
+                                    ${v.status === 'pending_review' ? `
+                                        <button class="btn btn-sm btn-success approve-btn" data-id="${v._id}">Approve</button>
+                                        <button class="btn btn-sm btn-danger reject-btn" data-id="${v._id}">Reject</button>
+                                    ` : ''}
                                 </div>
                             </td>
                         </tr>
@@ -811,9 +800,21 @@
                     });
                 });
                 
-                document.querySelectorAll('.view-details').forEach(btn => {
+               document.querySelectorAll('.view-details').forEach(btn => {
+                   btn.addEventListener('click', function() {
+                       viewVerificationDetails(this.getAttribute('data-id'));
+                   });
+               });
+
+                document.querySelectorAll('.approve-btn').forEach(btn => {
                     btn.addEventListener('click', function() {
-                        viewVerificationDetails(this.getAttribute('data-id'));
+                        reviewVerification(this.getAttribute('data-id'), 'approved');
+                    });
+                });
+
+                document.querySelectorAll('.reject-btn').forEach(btn => {
+                    btn.addEventListener('click', function() {
+                        reviewVerification(this.getAttribute('data-id'), 'rejected');
                     });
                 });
             }
@@ -907,6 +908,31 @@
                     }
                 } catch (error) {
                     console.error('Override error:', error);
+                    alert(`Error: ${error.message}`);
+                }
+            }
+
+            async function reviewVerification(id, decision) {
+                try {
+                    const adminToken = window.parent.localStorage.getItem('adminToken');
+                    if (!adminToken) {
+                        throw new Error('Authentication token missing');
+                    }
+
+                    const response = await fetch('/api/kyc/review', {
+                        method: 'POST',
+                        headers: {
+                            'Authorization': `Bearer ${adminToken}`,
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({ verificationId: id, decision })
+                    });
+
+                    if (!response.ok) throw new Error('Failed to update verification');
+
+                    loadVerificationData();
+                } catch (error) {
+                    console.error('Review error:', error);
                     alert(`Error: ${error.message}`);
                 }
             }

--- a/api.php
+++ b/api.php
@@ -243,6 +243,20 @@ if ($endpoint === 'kyc' || (isset($pathParts) && $pathParts[0] === 'kyc')) {
                 exit;
             }
             break;
+
+        case 'pending':
+            if ($method === 'GET') {
+                $kycController->listPending();
+                exit;
+            }
+            break;
+
+        case 'review':
+            if ($method === 'POST') {
+                $kycController->reviewVerification();
+                exit;
+            }
+            break;
             
         case 'status':
             if ($method === 'GET') {

--- a/kyc-api.php
+++ b/kyc-api.php
@@ -54,6 +54,26 @@ try {
             }
             $kycController->handleWebhook();
             break;
+
+        case 'pending':
+            // GET /api/kyc/pending - List verifications awaiting review
+            if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+                http_response_code(405);
+                echo json_encode(['error' => 'Method not allowed']);
+                exit;
+            }
+            $kycController->listPending();
+            break;
+
+        case 'review':
+            // POST /api/kyc/review - Approve or reject a verification
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                http_response_code(405);
+                echo json_encode(['error' => 'Method not allowed']);
+                exit;
+            }
+            $kycController->reviewVerification();
+            break;
             
         case 'admin-override':
             // POST /api/kyc/admin-override - Admin override for verification

--- a/lib/Verification.php
+++ b/lib/Verification.php
@@ -17,6 +17,11 @@ class Verification extends Collection {
     const STATE_SELFIE_UPLOAD = 'selfie_upload';
     const STATE_REVIEW = 'review';
     const STATE_COMPLETE = 'complete';
+
+    // Review statuses
+    const STATUS_PENDING_REVIEW = 'pending_review';
+    const STATUS_APPROVED = 'approved';
+    const STATUS_REJECTED = 'rejected';
     
     // Approval steps
     const STEP_DOCUMENT_VERIFICATION = 'document_verification';
@@ -562,9 +567,9 @@ class Verification extends Collection {
             
             // Initialize default stats
             $stats = [
-                'pending' => 0,
-                'approved' => 0,
-                'rejected' => 0
+                self::STATUS_PENDING_REVIEW => 0,
+                self::STATUS_APPROVED => 0,
+                self::STATUS_REJECTED => 0
             ];
 
             // Update stats with actual counts
@@ -579,9 +584,9 @@ class Verification extends Collection {
         } catch (Exception $e) {
             error_log("Error getting verification stats: " . $e->getMessage());
             return [
-                'pending' => 0,
-                'approved' => 0,
-                'rejected' => 0
+                self::STATUS_PENDING_REVIEW => 0,
+                self::STATUS_APPROVED => 0,
+                self::STATUS_REJECTED => 0
             ];
         }
     }


### PR DESCRIPTION
## Summary
- expand `Verification` with pending_review/approved/rejected states
- provide KYC endpoints for listing and reviewing pending verifications
- wire new admin review workflow in API routing
- enhance admin UI to approve or reject KYC verifications

## Testing
- `php -l lib/KycController.php`
- `php -l kyc-api.php`
- `php -l api.php`
- `php -l lib/Verification.php`
- `php -l admin/kyc-admin.html`
- `php run-tests.php` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fe876c4fc8323b6bc748b69dcbb6e