### PR TITLE
Add multisig support

### DIFF
--- a/lib/StellarTransactionBuilder.js
+++ b/lib/StellarTransactionBuilder.js
@@ -75,12 +75,24 @@ class StellarTransactionBuilder {
       
       // Sign the transaction
       transaction.sign(sourceKeypair);
-      
+
       return transaction;
     } catch (error) {
       console.error('Error building transaction:', error);
       throw error;
     }
+  }
+
+  /**
+   * Add additional signatures to a transaction
+   * @param {Transaction} transaction Transaction to sign
+   * @param {string[]} signerSecrets Array of secret keys
+   */
+  addSignatures(transaction, signerSecrets = []) {
+    signerSecrets.forEach(secret => {
+      const keypair = StellarSdk.Keypair.fromSecret(secret);
+      transaction.sign(keypair);
+    });
   }
 
   /**
@@ -91,6 +103,11 @@ class StellarTransactionBuilder {
    */
   async submitTransaction(transaction, options = {}) {
     let lastError;
+    const signerSecrets = options.signerSecrets || [];
+
+    if (signerSecrets.length) {
+      this.addSignatures(transaction, signerSecrets);
+    }
     
     for (let attempt = 1; attempt <= this.maxRetries; attempt++) {
       try {
@@ -121,7 +138,7 @@ class StellarTransactionBuilder {
           // If fee-related error, try with higher fee
           if (this.feeManager.isFeeRelatedError(error) && options.sourceSecret) {
             try {
-              transaction = await this.retryWithHigherFee(transaction, options.sourceSecret);
+              transaction = await this.retryWithHigherFee(transaction, options.sourceSecret, signerSecrets);
             } catch (feeError) {
               console.error('Error creating fee bump transaction:', feeError);
             }
@@ -169,7 +186,7 @@ class StellarTransactionBuilder {
    * @param {string} sourceSecret Source account secret key
    * @returns {Promise<Transaction>} New transaction with higher fee
    */
-  async retryWithHigherFee(transaction, sourceSecret) {
+  async retryWithHigherFee(transaction, sourceSecret, signerSecrets = []) {
     const sourceKeypair = StellarSdk.Keypair.fromSecret(sourceSecret);
     
     // Get a higher fee
@@ -188,6 +205,10 @@ class StellarTransactionBuilder {
     
     // Sign and return
     bumpTransaction.sign(sourceKeypair);
+    signerSecrets.forEach(secret => {
+      const keypair = StellarSdk.Keypair.fromSecret(secret);
+      bumpTransaction.sign(keypair);
+    });
     return bumpTransaction;
   }
 

--- a/lib/TransactionService.js
+++ b/lib/TransactionService.js
@@ -101,12 +101,18 @@ class TransactionService {
         isAnonymous = false,
         message = "",
         recurring = false,
-        recurringFrequency = "monthly"
+        recurringFrequency = "monthly",
+        signerSecrets = [],
+        multisig = false
       } = params;
       
       // Validate required parameters
       if (!donorId || !campaignId || !amount || !sourceSecret) {
         throw new Error('Missing required parameters for donation');
+      }
+
+      if (multisig && signerSecrets.length < 1) {
+        throw new Error('Multisig transactions require additional signer secrets');
       }
       
       // Get campaign details from database
@@ -131,6 +137,7 @@ class TransactionService {
         transaction: {
           status: 'pending'
         },
+        multisig: multisig,
         type: recurring ? 'recurring' : 'one-time',
         status: 'pending',
         visibility: isAnonymous ? 'anonymous' : 'public',
@@ -173,7 +180,7 @@ class TransactionService {
         // Submit the transaction with retry and fee bump options
         const submissionResult = await this.stellarBuilder.submitTransaction(
           recurringResult.transaction,
-          { sourceSecret } // Pass source secret for potential fee bumps
+          { sourceSecret, signerSecrets } // Include additional signatures
         );
         
         if (submissionResult.success) {
@@ -230,7 +237,7 @@ class TransactionService {
         // Submit the transaction with retry and fee bump options
         const submissionResult = await this.stellarBuilder.submitTransaction(
           transaction,
-          { sourceSecret } // Pass source secret for potential fee bumps
+          { sourceSecret, signerSecrets } // Include additional signatures
         );
         
         if (submissionResult.success) {
@@ -1038,7 +1045,7 @@ class TransactionService {
    */
   async cancelRecurringDonation(params) {
     try {
-      const { donorId, campaignId, userId } = params;
+      const { donorId, campaignId, userId, signerSecrets = [] } = params;
 
       // Verify user authorization (must be the donor or an admin)
       if (donorId.toString() !== userId.toString()) {
@@ -1082,7 +1089,9 @@ class TransactionService {
       });
 
       // Submit the transaction
-      const result = await this.stellarBuilder.submitTransaction(transaction);
+      const result = await this.stellarBuilder.submitTransaction(transaction, {
+        signerSecrets
+      });
 
       if (!result.success) {
         throw new Error(`Failed to submit cancellation transaction: ${result.error}`);

--- a/schemas/blockchain_transactions.js
+++ b/schemas/blockchain_transactions.js
@@ -119,6 +119,10 @@ db.createCollection("blockchain_transactions", {
           bsonType: "int",
           description: "Number of confirmations (for blockchains that use this concept)"
         },
+        multisig: {
+          bsonType: "bool",
+          description: "Whether the transaction requires multiple signatures"
+        },
         createdAt: {
           bsonType: "date",
           description: "When the transaction record was created"


### PR DESCRIPTION
## Summary
- expand `blockchain_transactions` schema with a `multisig` flag
- allow `StellarTransactionBuilder` to add additional signatures and pass them to fee-bump retries
- update `TransactionService` to handle multisig donations and cancellations

## Testing
- `composer install --ignore-platform-reqs`
- `./vendor/bin/phpunit` *(fails: Class "MongoDB\\Driver\\Manager" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe872dc848323876a684e5110fa49