### PR TITLE
Add milestone creation page and timeline chart

### DIFF
--- a/pages/campaign-detail.html
+++ b/pages/campaign-detail.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@100..800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.0/chart.umd.min.js"></script>
     <style>
         :root {
             --background-color: #f4f4f9;
@@ -553,7 +554,7 @@
         <div class="card">
             <h2 class="section-title">Milestones</h2>
             <ul id="milestones" class="milestones"></ul>
-            <div id="timeline" class="timeline"></div>
+            <canvas id="timeline-chart" style="width:100%;max-height:300px;"></canvas>
         </div>
 
         <div class="card">
@@ -580,7 +581,8 @@
             map: null,
             id: null,
             isEditMode: false,
-            originalData: null
+            originalData: null,
+            timelineChart: null
         },
         init() {
             const query = app.utils.parseSearch();
@@ -890,7 +892,8 @@
             const milestones = data.timeline?.milestones || [];
             if (milestones.length === 0) {
                 $('#milestones').innerHTML = '<li>No milestones available.</li>';
-                $('#timeline').innerHTML = '<p>No timeline data.</p>';
+                const canvas = document.getElementById('timeline-chart');
+                if (canvas) canvas.outerHTML = '<p id="timeline-chart">No timeline data.</p>';
             } else {
                 const milestonesHtml = data.timeline.milestones.map(milestone => `
                     <li>
@@ -934,24 +937,45 @@
         },
         renderTimeline() {
             const milestones = app.data.timeline?.milestones || [];
-            const container = document.getElementById('timeline');
-            if (!container) return;
+            const ctxEl = document.getElementById('timeline-chart');
+            if (!ctxEl) return;
             if (milestones.length === 0) {
-                container.innerHTML = '<p>No timeline data.</p>';
+                ctxEl.outerHTML = '<p id="timeline-chart">No timeline data.</p>';
                 return;
             }
-            const itemsHtml = milestones.map(m => {
-                const date = m.scheduledDate ? `<span class="timeline-date">${app.utils.formatDate(m.scheduledDate)}</span>` : '';
-                const amount = m.amount ? `<span class="timeline-date">${app.utils.formatCurrency(m.amount)}</span>` : '';
-                return `
-                    <div class="timeline-item">
-                        <h4>${m.title}</h4>
-                        ${[date, amount].filter(Boolean).join(' ')}
-                        <p class="text-gray-600">${m.description || ''}</p>
-                    </div>
-                `;
-            }).join('');
-            container.innerHTML = itemsHtml;
+            const labels = milestones.map(m => m.title);
+            const data = milestones.map((m, idx) => ({
+                x: m.scheduledDate ? new Date(m.scheduledDate) : new Date(),
+                y: idx
+            }));
+            if (app.state.timelineChart) {
+                app.state.timelineChart.destroy();
+            }
+            app.state.timelineChart = new Chart(ctxEl.getContext('2d'), {
+                type: 'scatter',
+                data: { datasets: [{ label: 'Milestones', data, backgroundColor: '#2563eb' }] },
+                options: {
+                    responsive: true,
+                    scales: {
+                        x: { type: 'time', title: { display: true, text: 'Date' } },
+                        y: {
+                            ticks: {
+                                callback: (val) => labels[val] || ''
+                            },
+                            min: -1,
+                            max: labels.length
+                        }
+                    },
+                    plugins: {
+                        tooltip: {
+                            callbacks: {
+                                label: ctx => labels[ctx.parsed.y]
+                            }
+                        },
+                        legend: { display: false }
+                    }
+                }
+            });
         },
         renderMap(lat, lng, txt) {
             if (app.state.map) {

--- a/pages/campaign-edit.html
+++ b/pages/campaign-edit.html
@@ -377,6 +377,16 @@
             flex: 1;
         }
 
+        .budget-summary {
+            margin-top: 8px;
+            font-size: 0.875rem;
+            color: var(--gray-600);
+        }
+
+        .budget-warning {
+            color: var(--danger-color);
+        }
+
         .notification {
             position: fixed;
             top: 20px;
@@ -1203,6 +1213,7 @@
                 </div>
             </h2>
             <ul id="milestones" class="milestones"></ul>
+            <div id="budget-summary" class="budget-summary"></div>
         </div>
 
         <div class="card">
@@ -2029,6 +2040,23 @@ Thanks for considering,
                 
                 milestonesContainer.appendChild(li);
             });
+
+            this.renderBudgetSummary();
+        },
+
+        renderBudgetSummary() {
+            const container = document.getElementById('budget-summary');
+            if (!container) return;
+            const goal = parseFloat($('#goal-amount').value || this.data.funding?.goalAmount || 0);
+            const total = (this.data.timeline?.milestones || []).reduce((s, m) => s + (parseFloat(m.amount) || 0), 0);
+            const remaining = goal - total;
+            let html = `Total budgeted: ${this.utils.formatCurrency(total)} / Goal: ${this.utils.formatCurrency(goal)}`;
+            if (remaining < 0) {
+                html += `<span class="budget-warning"> - Over by ${this.utils.formatCurrency(-remaining)}</span>`;
+            } else {
+                html += ` - Remaining ${this.utils.formatCurrency(remaining)}`;
+            }
+            container.innerHTML = html;
         },
         
         renderMediaGallery() {
@@ -2283,11 +2311,26 @@ Thanks for considering,
 
         saveMilestone() {
             const id = $('#milestone-id').value;
+            const amountVal = parseFloat($('#milestone-amount').value);
+            if (amountVal < 0) {
+                this.utils.showNotification('Amount must be non-negative', 'error');
+                return;
+            }
+            const dateVal = $('#milestone-date').value;
+            if (dateVal) {
+                const selected = new Date(dateVal);
+                const today = new Date();
+                today.setHours(0,0,0,0);
+                if (selected < today) {
+                    this.utils.showNotification('Scheduled date cannot be in the past', 'error');
+                    return;
+                }
+            }
             const newMilestone = {
                 title: $('#milestone-title').value,
                 description: $('#milestone-description').value,
-                amount: parseFloat($('#milestone-amount').value) || 0,
-                scheduledDate: $('#milestone-date').value ? new Date($('#milestone-date').value).toISOString() : null,
+                amount: isNaN(amountVal) ? 0 : amountVal,
+                scheduledDate: dateVal ? new Date(dateVal).toISOString() : null,
                 status: $('#milestone-status').value
             };
             

--- a/pages/milestone-form.html
+++ b/pages/milestone-form.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Create Milestone</title>
+    <link rel="stylesheet" href="../style.css">
+    <style>
+        .container { max-width: 600px; margin: 2rem auto; background: #fff; padding: 1rem; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,0.1); }
+        label { display:block; margin-top:1rem; }
+        input, textarea, select { width:100%; padding:0.5rem; margin-top:0.25rem; }
+        .actions { margin-top:1rem; display:flex; gap:1rem; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>Create Milestone</h2>
+    <form id="milestone-form">
+        <label for="title">Title</label>
+        <input type="text" id="title" required>
+        <label for="description">Description</label>
+        <textarea id="description" required></textarea>
+        <label for="amount">Budget Amount (USD)</label>
+        <input type="number" id="amount" min="0" step="0.01" required>
+        <label for="date">Scheduled Date</label>
+        <input type="date" id="date">
+        <label for="status">Status</label>
+        <select id="status">
+            <option value="pending">Pending</option>
+            <option value="active">Active</option>
+            <option value="completed">Completed</option>
+        </select>
+        <div class="actions">
+            <button type="submit">Save</button>
+            <button type="button" onclick="history.back()">Cancel</button>
+        </div>
+    </form>
+</div>
+<script>
+(function(){
+    const form = document.getElementById('milestone-form');
+    form.addEventListener('submit', e => {
+        e.preventDefault();
+        const amount = parseFloat(document.getElementById('amount').value);
+        if(isNaN(amount) || amount < 0){
+            alert('Amount must be non-negative');
+            return;
+        }
+        const dateVal = document.getElementById('date').value;
+        if(dateVal){
+            const d = new Date(dateVal);
+            const today = new Date();
+            today.setHours(0,0,0,0);
+            if(d < today){
+                alert('Scheduled date cannot be in the past');
+                return;
+            }
+        }
+        const milestone = {
+            title: document.getElementById('title').value,
+            description: document.getElementById('description').value,
+            amount: amount,
+            scheduledDate: dateVal ? new Date(dateVal).toISOString() : null,
+            status: document.getElementById('status').value
+        };
+        console.log('Milestone data', milestone);
+        alert('Milestone validated. Implement API call as needed.');
+    });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- validate milestone inputs and track total budget in campaign editor
- show budget allocation summary
- display milestone timeline with Chart.js
- add simple standalone milestone creation form

## Testing
- `./scripts/setup-tests.sh`
- `php8.3 vendor/bin/phpunit --configuration phpunit.xml` *(fails: Tests: 23, Assertions: 55, Errors: 1, Failures: 11)*

------
https://chatgpt.com/codex/tasks/task_e_687fe86bc20483238d87445e5d5e7c3c