### PR TITLE
Add liveness video check to KYC flow

### DIFF
--- a/kyc-api.php
+++ b/kyc-api.php
@@ -105,6 +105,16 @@ try {
             $kycController->generateComplianceReport();
             break;
 
+        case 'liveness':
+            // POST /api/kyc/liveness - Perform secondary liveness check
+            if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+                http_response_code(405);
+                echo json_encode(['error' => 'Method not allowed']);
+                exit;
+            }
+            $kycController->performLivenessCheck();
+            break;
+
         case 'risk-score':
             // POST /api/kyc/risk-score - Calculate and update risk score
             if ($_SERVER['REQUEST_METHOD'] !== 'POST') {

--- a/lib/id-verify.js
+++ b/lib/id-verify.js
@@ -25,6 +25,7 @@
       'Personal Information',
       'Upload ID Document',
       'Take Selfie',
+      'Liveness Check',
       'Review Information'
     ];
     document.querySelector('.card-header h2').textContent = stepTitles[stepNumber - 1];
@@ -45,7 +46,7 @@
       // For any step other than selfie, stop the webcam
       stopWebcam();
       
-      if (stepNumber === 4) {
+      if (stepNumber === 5) {
         // Update review content in step 4
         document.getElementById('review-name').textContent = 
           `${sessionStorage.getItem('firstName') || ''} ${sessionStorage.getItem('lastName') || ''}`;

--- a/pages/kyc-verification.html
+++ b/pages/kyc-verification.html
@@ -84,7 +84,9 @@
                                 <div class="step-divider"></div>
                                 <div class="step-indicator" data-step="3">Selfie</div>
                                 <div class="step-divider"></div>
-                                <div class="step-indicator" data-step="4">Review</div>
+                                <div class="step-indicator" data-step="4">Liveness</div>
+                                <div class="step-divider"></div>
+                                <div class="step-indicator" data-step="5">Review</div>
                             </div>
 
                             <div class="step-content active" data-step="1">
@@ -185,11 +187,32 @@
                                 </div>
                                 <div class="button-group">
                                     <button type="button" id="backToDocument" class="btn btn-secondary">Back</button>
-                                    <button type="button" id="nextToReview" class="btn btn-primary" disabled>Continue</button>
+                                    <button type="button" id="nextToLiveness" class="btn btn-primary" disabled>Continue</button>
                                 </div>
                             </div>
 
                             <div class="step-content" data-step="4">
+                                <h3>Liveness Check</h3>
+                                <div class="liveness-container">
+                                    <video id="livenessVideo" autoplay playsinline></video>
+                                    <button type="button" id="captureLiveness" class="btn btn-primary">Record Video</button>
+                                </div>
+                                <div class="upload-alternative">
+                                    <p>Or upload a video:</p>
+                                    <input type="file" id="livenessInput" accept="video/*" style="display: none;">
+                                    <button type="button" id="livenessUpload" class="btn btn-outline-primary">Upload Video</button>
+                                </div>
+                                <div id="livenessPreview" class="preview-container" style="display: none;">
+                                    <video src="" controls></video>
+                                    <button type="button" id="removeLiveness" class="btn btn-sm btn-danger">Remove</button>
+                                </div>
+                                <div class="button-group">
+                                    <button type="button" id="backToSelfie" class="btn btn-secondary">Back</button>
+                                    <button type="button" id="nextToReview" class="btn btn-primary" disabled>Continue</button>
+                                </div>
+                            </div>
+
+                            <div class="step-content" data-step="5">
                                 <h3>Review Information</h3>
                                 <div class="review-section">
                                     <div class="review-item">


### PR DESCRIPTION
## Summary
- support uploading liveness videos in `Documents`
- add API route and controller method for secondary liveness checks
- surface liveness result in `/api/kyc/status`
- extend the verification frontend with a liveness step
- update step titles for the new flow

## Testing
- `php -d detect_unicode=0 run-tests.php` *(fails: Failed opening required '/workspace/app/vendor/autoload.php')*
- `composer install` *(fails: ext-mongodb missing)*

------
https://chatgpt.com/codex/tasks/task_e_687fef2079048323a1a2d7833141a1ad