### PR TITLE
Implement notification service

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpseclib/bcmath_compat": "^2.0",
         "square/square": "^40.0",
         "aws/aws-sdk-php": "^3.337",
-        "vlucas/phpdotenv": "^5.5"
+        "vlucas/phpdotenv": "^5.5",
+        "twilio/sdk": "^6"
     },
     "autoload": {
         "classmap": [

--- a/lib/AdminCampaignController.php
+++ b/lib/AdminCampaignController.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/db.php';
 require_once __DIR__ . '/Auth.php';
+require_once __DIR__ . '/NotificationService.php';
 
 class AdminCampaignController {
     private $collection;
@@ -297,8 +298,19 @@ class AdminCampaignController {
             ];
             
             $notifications->insertOne($notification);
-            
-            // In a real app, you would also send an email here
+
+            // Dispatch external alerts
+            $users = $db->getCollection('users');
+            $creator = $users->findOne(['_id' => new MongoDB\BSON\ObjectId($campaign['creatorId'])]);
+            $email = $creator['email'] ?? '';
+            $phone = $creator['personalInfo']['phone'] ?? '';
+            $notifier = new NotificationService();
+            $notifier->send(
+                'Campaign Approved',
+                "Your campaign '{$campaign['title']}' is now live!",
+                array_filter([$email]),
+                array_filter([$phone])
+            );
         } catch (Exception $e) {
             error_log("Error sending approval notification: " . $e->getMessage());
         }
@@ -327,8 +339,19 @@ class AdminCampaignController {
             ];
             
             $notifications->insertOne($notification);
-            
-            // In a real app, you would also send an email here
+
+            // Dispatch external alerts
+            $users = $db->getCollection('users');
+            $creator = $users->findOne(['_id' => new MongoDB\BSON\ObjectId($campaign['creatorId'])]);
+            $email = $creator['email'] ?? '';
+            $phone = $creator['personalInfo']['phone'] ?? '';
+            $notifier = new NotificationService();
+            $notifier->send(
+                'Campaign Rejected',
+                "Your campaign '{$campaign['title']}' requires changes. Feedback: {$feedback}",
+                array_filter([$email]),
+                array_filter([$phone])
+            );
         } catch (Exception $e) {
             error_log("Error sending rejection notification: " . $e->getMessage());
         }

--- a/lib/Document.php
+++ b/lib/Document.php
@@ -3,6 +3,7 @@
 require_once __DIR__ . '/db.php';
 require_once __DIR__ . '/Auth.php';
 require_once __DIR__ . '/DocumentUploader.php';
+require_once __DIR__ . '/NotificationService.php';
 
 class Document {
     private $db;
@@ -459,6 +460,18 @@ class Document {
                 $document['type'],
                 $status
             );
+
+            // Dispatch notification about verification result
+            try {
+                $notifier = new NotificationService();
+                $subject = 'Document Verification ' . ucfirst($status);
+                $message = "Your {$document['type']} document has been {$status}.";
+                $emails = [$document['userEmail'] ?? ''];
+                $phones = [$document['userPhone'] ?? ''];
+                $notifier->send($subject, $message, array_filter($emails), array_filter($phones));
+            } catch (Exception $e) {
+                error_log('Notification error: ' . $e->getMessage());
+            }
             
             return [
                 'success' => true,

--- a/lib/NotificationService.php
+++ b/lib/NotificationService.php
@@ -1,0 +1,79 @@
+<?php
+require_once __DIR__ . '/Mailer.php';
+require_once __DIR__ . '/config.php';
+
+use Twilio\Rest\Client;
+
+/**
+ * Service for sending notifications across multiple channels
+ * (email, SMS, Slack) following the pattern from docs/transaction-system/best-practices.html
+ */
+class NotificationService {
+    private $mailer;
+    private $smsClient;
+    private $slackWebhook;
+    private $smsFrom;
+
+    public function __construct($config = []) {
+        $this->mailer = $config['mailer'] ?? new Mailer();
+
+        $sid = $config['twilioSid'] ?? (defined('TWILIO_SID') ? TWILIO_SID : null);
+        $token = $config['twilioToken'] ?? (defined('TWILIO_TOKEN') ? TWILIO_TOKEN : null);
+        $this->smsFrom = $config['smsFrom'] ?? (defined('SMS_FROM') ? SMS_FROM : null);
+        if ($sid && $token) {
+            $this->smsClient = new Client($sid, $token);
+        }
+
+        $this->slackWebhook = $config['slackWebhook'] ?? (defined('SLACK_WEBHOOK_URL') ? SLACK_WEBHOOK_URL : null);
+    }
+
+    /**
+     * Send notification message to configured channels
+     *
+     * @param string $subject Subject or title of the notification
+     * @param string $message Main text of the notification
+     * @param array $emails List of email addresses to notify
+     * @param array $phones List of phone numbers for SMS
+     */
+    public function send($subject, $message, $emails = [], $phones = []) {
+        // Email notification
+        if (!empty($emails)) {
+            foreach ($emails as $email) {
+                try {
+                    $this->mailer->sendNotification($email, $subject, $message);
+                } catch (\Throwable $e) {
+                    error_log('Failed to send email notification: ' . $e->getMessage());
+                }
+            }
+        }
+
+        // SMS notification
+        if ($this->smsClient && $this->smsFrom && !empty($phones)) {
+            foreach ($phones as $phone) {
+                try {
+                    $this->smsClient->messages->create($phone, [
+                        'from' => $this->smsFrom,
+                        'body' => $subject . ' - ' . $message
+                    ]);
+                } catch (\Throwable $e) {
+                    error_log('Failed to send SMS notification: ' . $e->getMessage());
+                }
+            }
+        }
+
+        // Slack notification
+        if ($this->slackWebhook) {
+            $payload = json_encode(['text' => "*{$subject}*\n{$message}"]);
+            $ch = curl_init($this->slackWebhook);
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+            curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            $res = curl_exec($ch);
+            if ($res === false) {
+                error_log('Failed to send Slack notification: ' . curl_error($ch));
+            }
+            curl_close($ch);
+        }
+    }
+}

--- a/lib/config.php
+++ b/lib/config.php
@@ -18,3 +18,12 @@ define('UPLOAD_DIR', __DIR__ . '/../img/avatars');
 // API URLs
 define('API_DOCS_URL', 'https://docs.thegivehub.com');
 define('DEV_PORTAL_URL', 'https://developers.thegivehub.com');
+
+// Notification service credentials
+define('TWILIO_SID', getenv('TWILIO_SID') ?: '');
+define('TWILIO_TOKEN', getenv('TWILIO_TOKEN') ?: '');
+define('SMS_FROM', getenv('SMS_FROM') ?: '');
+define('SLACK_WEBHOOK_URL', getenv('SLACK_WEBHOOK_URL') ?: '');
+// Default admin contacts for notifications
+define('ADMIN_EMAILS', getenv('ADMIN_EMAILS') ?: '');
+define('ADMIN_PHONES', getenv('ADMIN_PHONES') ?: '');


### PR DESCRIPTION
## Summary
- add Twilio dependency
- create `NotificationService` for email/SMS/Slack alerts
- update config with notification credentials
- send notifications on document verification results
- send notifications on campaign approval/rejection

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: Class "MongoDB\\Driver\\Manager" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fef2008688323addb0f6a8ac2e8f3