### PR TITLE
Add script to auto-update tracker tasks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,3 +99,14 @@ If you encounter issues with "Invalid base64 image format" errors:
 2. Check if your images actually use the standard base64 format: `data:image/jpeg;base64,/9j/...`
 3. If your database contains URLs instead of base64 data, the script will now automatically detect and keep them
 4. For invalid data, you can manually update records after migration 
+## Task Management
+
+The `update_unfinished_tasks.sh` script helps reconcile the project tracker with the repository history. It fetches tasks from the remote API, searches commit messages for matching task names, and updates each task's notes with the commit hash. If an unfinished task has a matching commit, it is automatically marked as completed.
+
+Run the script from the repository root:
+
+```bash
+bash scripts/update_unfinished_tasks.sh
+```
+
+Ensure you have network access to `project.thegivehub.com` and appropriate permissions before running.

--- a/scripts/update_unfinished_tasks.sh
+++ b/scripts/update_unfinished_tasks.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This script checks the project task API for tasks that are unfinished or missing notes
+# and attempts to find matching git commits by task name. If a commit is found,
+# the task notes are updated with the commit hash and the task is marked as completed.
+
+set -e
+API_URL="https://project.thegivehub.com/handle_tasks.php"
+
+# Fetch all tasks
+TASKS_JSON=$(curl -s "$API_URL")
+
+echo "$TASKS_JSON" | jq -c '.[] | select(.completed=="0" or .notes==null or .notes=="") | {id, task_name, completed}' | while read -r row; do
+    id=$(echo "$row" | jq -r '.id')
+    name=$(echo "$row" | jq -r '.task_name')
+    completed=$(echo "$row" | jq -r '.completed')
+    search=$(echo "$name" | sed 's/[].*^$\/]/\\&/g')
+    commit=$(git log --grep="$search" -n 1 --pretty=format:%h || true)
+    if [ -n "$commit" ]; then
+        note="Completed in commit $commit"
+        # Update note
+        curl -s -X POST "$API_URL" -d "action=update_notes&task_id=$id&notes=$(echo $note | sed 's/ /%20/g')" >/dev/null
+        # Mark complete if not already
+        if [ "$completed" = "0" ]; then
+            curl -s -X POST "$API_URL" -d "action=update&task_id=$id&completed=1" >/dev/null
+        fi
+        echo "Updated task $id with commit $commit"
+    else
+        echo "No matching commit found for task $id - $name" >&2
+    fi
+
+done


### PR DESCRIPTION
## Summary
- automate updating open tasks in project tracker
- document the new script in `scripts/README.md`

## Testing
- `php ./run-tests.php` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: ext-mongodb missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887c7614760832393dbb21ff9fbaad0