### PR TITLE
Implement offline fallback page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1040,5 +1040,13 @@
         });
       })();
     </script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/service-worker.js')
+                    .catch(err => console.error('Service worker registration failed', err));
+            });
+        }
+    </script>
   </body>
 </html>

--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Offline - GiveHub</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>You are offline</h1>
+        <p>Please check your internet connection.</p>
+    </div>
+</body>
+</html>

--- a/offline.html
+++ b/offline.html
@@ -7,9 +7,10 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="container">
+    <div class="container" style="text-align:center; margin-top:20vh;">
         <h1>You are offline</h1>
-        <p>Please check your internet connection.</p>
+        <p>Please check your internet connection and try again.</p>
+        <p><a href="/" onclick="location.reload()">Reload Page</a></p>
     </div>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,35 @@
+const CACHE_NAME = 'givehub-cache-v1';
+const OFFLINE_URLS = [
+    '/',
+    '/index.html',
+    '/offline.html',
+    '/app.js',
+    '/style.css',
+    '/img/white-logo.svg'
+];
+
+self.addEventListener('install', event => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_URLS))
+    );
+});
+
+self.addEventListener('activate', event => {
+    event.waitUntil(
+        caches.keys().then(keys =>
+            Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+        )
+    );
+});
+
+self.addEventListener('fetch', event => {
+    if (event.request.mode === 'navigate') {
+        event.respondWith(
+            fetch(event.request).catch(() => caches.match('/offline.html'))
+        );
+        return;
+    }
+    event.respondWith(
+        caches.match(event.request).then(resp => resp || fetch(event.request))
+    );
+});

--- a/service-worker.js
+++ b/service-worker.js
@@ -18,7 +18,7 @@ self.addEventListener('activate', event => {
     event.waitUntil(
         caches.keys().then(keys =>
             Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
-        )
+        ).then(() => self.clients.claim())
     );
 });
 


### PR DESCRIPTION
## Summary
- add offline fallback page
- update service worker to return offline page for navigation requests

## Testing
- `composer install --ignore-platform-req=ext-mongodb`
- `./vendor/bin/phpunit` *(fails: Class "MongoDB\Driver\Manager" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887d11364bc8323b0cc9625f16b77f1